### PR TITLE
Use a smaller font while displaying IP numbers and SSID names

### DIFF
--- a/anavi-miracle-controller-sw/anavi-miracle-controller-sw.ino
+++ b/anavi-miracle-controller-sw/anavi-miracle-controller-sw.ino
@@ -528,7 +528,7 @@ void setup()
     wifiManager.setTimeout(300);
 
     digitalWrite(pinAlarm, HIGH);
-    drawDisplay("Connecting...", WiFi.SSID().c_str());
+    drawDisplay("Connecting...", WiFi.SSID().c_str(), "", true);
 
     //fetches ssid and pass and tries to connect
     //if it does not connect it starts an access point
@@ -604,7 +604,8 @@ void setup()
 
     Serial.println("local ip");
     Serial.println(WiFi.localIP());
-    drawDisplay("Connected!", "Local IP:", WiFi.localIP().toString().c_str());
+    drawDisplay("Connected!", "Local IP:", WiFi.localIP().toString().c_str(),
+                true);
     delay(2000);
 
     // Sensors


### PR DESCRIPTION
This ensures all IP addresses will fit, and increases the likelihood
that SSID names will fit.